### PR TITLE
ExaCC - Ansible resource creation not working due to excluded parameter db_version

### DIFF
--- a/plugins/modules/oci_database_database.py
+++ b/plugins/modules/oci_database_database.py
@@ -1136,7 +1136,7 @@ class DatabaseHelperGen(OCIResourceHelperBase):
         return CreateDatabaseBase
 
     def get_exclude_attributes(self):
-        return ["db_version", "database", "source"]
+        return ["database", "source"]
 
     def create_resource(self):
         create_details = self.get_create_model()


### PR DESCRIPTION
Dear,

May I ask to review this request ! Indeed, while trying to provision a new database on ExaCC the module just returns with status OK and never creates any resource.

While looking at plugins/modules/oci_database_database.py we quickly identified that the method

```
    def get_exclude_attributes(self):
        return ["db_version", "database", "source"]
```

is wrong as according to the doc. we need to provide the dataabse home OCID and the exact db_version
```
state=present, creates a new database in the specified Database Home. If the database version is provided, it must match the version of the Database Home. Applies to Exadata and Exadata [Cloud@Customer](mailto:Cloud%40Customer) systems.
```