### PR TITLE
Update oci_compute_volume_attachment_module.rst

### DIFF
--- a/docs/collections/oracle/oci/oci_compute_volume_attachment_module.rst
+++ b/docs/collections/oracle/oci/oci_compute_volume_attachment_module.rst
@@ -261,7 +261,7 @@ Parameters
                                 <td>
                                                                                                                                                             </td>
                                                                 <td>
-                                            <div>The device name. To retrieve a list of devices for a given instance, see <a href='https://docs.cloud.oracle.com/en- us/iaas/api/#/en/iaas/latest/Device/ListInstanceDevices'>ListInstanceDevices</a>.</div>
+                                            <div>The device name. To retrieve a list of devices for a given instance, see <a href='https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/Device'>ListInstanceDevices</a>.</div>
                                                         </td>
             </tr>
                                 <tr>


### PR DESCRIPTION
Maybe this is not the right place to change, but just reporting a broken link I got in the following page: https://oci-ansible-collection.readthedocs.io/en/latest/collections/oracle/oci/oci_compute_volume_attachment_module.html#ansible-collections-oracle-oci-oci-compute-volume-attachment-module
