### PR TITLE
add image_name, add more lifecycle_state and the boot_volume_id of the machine in the inventory

### DIFF
--- a/plugins/inventory/oci.py
+++ b/plugins/inventory/oci.py
@@ -1418,6 +1418,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     vnic_attachment, lifecycle_state=self.LIFECYCLE_ATTACHED_STATE
                 )
             ]
+            
+            availability_domain = instance.availability_domain
+            attachments = compute_client.list_boot_volume_attachments(
+                compartment_id=compartment.id,
+                instance_id=instance.id,
+                availability_domain=availability_domain  
+            ).data
+            boot_volume_ids = [attachment.boot_volume_id for attachment in attachments]
+            # add the id of the boot volume of the machine
+            instance_common_vars['boot_volume_id'] = boot_volume_ids
 
             for vnic_attachment in vnic_attachments:
                 instance_vars = instance_common_vars.copy()
@@ -1451,15 +1461,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                             )
                         )
                         continue
-                    attachments = compute_client.list_boot_volume_attachments(
-                        compartment_id=compartment.id,
-                        instance_id=instance.id,
-                        availability_domain=availability_domain  
-                    ).data
-                    boot_volume_ids = [attachment.boot_volume_id for attachment in attachments]
-                    # add the id of the boot volume of the machine
-                    instance_common_vars['boot_volume_id'] = boot_volume_ids
-                    
                     ipv6_ip_addresses = []
                     if self._get_enable_ipv6():
                         try:

--- a/plugins/inventory/oci.py
+++ b/plugins/inventory/oci.py
@@ -1403,7 +1403,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     image_name = image_details.display_name
                     instance_common_vars.update({"image_name": image_name})  
                 except ServiceError as e:
-                    self.debug(f"No se pudo obtener los detalles de la imagen para image_id {instance.image_id}: {e}")
+                    self.debug(f"It was not possible to obtain details for the image with image_id: {instance.image_id}: {e}")
                     
             common_groups = self.get_common_groups(instance=instance, region=region)
 


### PR DESCRIPTION
SUMMARY 
now besides the image_id it also returns the image_name and also by default now the inventory also picks up the machines (not db) that are in the following states: "PROVISIONING", "RUNNING", "STOPPING", "STOPPED", "STARTING"] that before only RUNNING was picked up. 
Also no data of the boot volumes of the machines is returned so added a way to return wht boot_volume_id.

ISSUE TYPE
- Inventory module feature request

COMPONENT NAME
oci  (oci.py)

ADDITIONAL INFORMATION
With this change is easier to make groups based on the OS running the machines, normally the image name in windows includes some text like "Win..."  so is easier to make linux and windows groups. Also now the inventory returns instances that are not just running, also stopped, stopping, provisioning or starting.

Before the change the information return (just a part)
```
                    },
                    "display_name": "server_name",
                    "extended_metadata": {},
                    "fault_domain": ",
                    "freeform_tags": {},
                    "id": "ocid123456q",
                    "image_id": "ocid1.image.oc1..223243434",
                    "instance_configuration_id": null,
                    "instance_options": {
                        "are_legacy_imds_endpoints_disabled": false
                    },
```

After the change 

```
                    },
                    "display_name": "server_name",
                    "extended_metadata": {},
                    "fault_domain": ",
                    "freeform_tags": {},
                    "id": "ocid123456q",
                    "image_id": "ocid1.image.oc1..223243434",
                    "image_name": "Oracle-linux..",
                    "instance_configuration_id": null,
                    "instance_options": {
                        "are_legacy_imds_endpoints_disabled": false
                    },
               # this is for the boot_volume_id
                    "availability_domain": ":EU-FRANKFURT-1",
                    "boot_volume_id": [
                        "ocid1.bootvolume.oc1.eu-frankfurt-1"
                    ],
```

